### PR TITLE
Implements the new @lag feature.

### DIFF
--- a/prometheus/worlds/plugins/Prometheus.xml
+++ b/prometheus/worlds/plugins/Prometheus.xml
@@ -8615,8 +8615,14 @@ sequence="100">
 CurrentGlobalSound = PlayGlobalSound("General/Misc/ghostMoan.ogg")
 </send>
 </trigger>
-</triggers>
-
+  <trigger
+   enabled="y"
+   match="LAG-TEST"
+   sequence="100"
+  >
+  <send>lag_result</send>
+  </trigger>
+  </triggers>
 <aliases>
 <alias match="ble *" enabled="y" ignore_case="y" sequence="100">
 <send>block %1 on ear</send></alias>


### PR DESCRIPTION
This pull request adds a new trigger. The trigger listens for the text "LAG-TEST" and responds by sending the command `lag_result`.

New trigger addition:

* Added a trigger that matches the string "LAG-TEST" and sends the `lag_result` command when detected.
* tested to ensure this does not fire under any other circumstances.


Closes #21.
